### PR TITLE
Fix the path in the settings.html to be relative..

### DIFF
--- a/settings.html
+++ b/settings.html
@@ -20,6 +20,6 @@
 </div>
 
 <script>
-    require('settings.js');
+    require('./settings.js');
 </script>
 </body>


### PR DESCRIPTION
Here is a PR to fix the setting of the port used to actually work. It changes it to a relative path. Can you please merge this, and rebuild for all platforms? This is noted in Issue #1 and #7, among others reported and the fix is commented in #1 as well.